### PR TITLE
Update live site link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository is an attempt at making GitHub issue data in the Jupyter ecosyst
 1. **Publishes issue data**. A GitHub workflow runs each day, scrapes the latest GitHub issues from a number of Jupyter sub-projects, and publishes them into a public location.
 2. **Shows issue tables**. A MyST website uses this data to display tables of issue metadata, sorted by sorted by community engagement (👍 and ❤️ reactions).
 
-**🔗 View the live site:** https://jupyter.org/github-issue-data/
+**🔗 View the live site:** <https://jupyter.org/issue-data/>
 
 _🚨 This is not an official Jupyter service, it is just an experiment at making issue data more useful to the community._
 

--- a/book/about.md
+++ b/book/about.md
@@ -21,12 +21,12 @@ More generally, it's useful to have access to a lot of issue metadata for many r
 
 Download `nox`:
 
-```
+```bash
 pip install nox
 ```
 
 Run the MyST server with `nox`:
 
-```
-nox -s start
+```bash
+nox -s docs-live
 ```


### PR DESCRIPTION
Update live site link in README `https://jupyter.org/github-issue-data/` to  `https://jupyter.org/issue-data/`